### PR TITLE
[Feature] Issue 13 Reverse Proxy for backend-service

### DIFF
--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -1,0 +1,62 @@
+# Workflows
+## Backend-Service Continuous Deployment Workflow
+This presumes the service is already running on your server on a docker compose network (see: <a href="../../backend-service/README.md">../../backend-service.README.md</a>)
+### Only runs on closed pull requests to main that affect `/backend-service`
+- can also be ran manually by `workflow_dispatch:` (useful for testing)
+```yaml
+on:
+  pull_request:
+    types: [closed]
+    branches:
+      - main
+    paths:
+      - 'backend-service/**'
+  workflow_dispatch:
+```
+
+### GitHub Actions Boilerplate Checkout and Copy SSH Keys
+```yaml
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@v3
+
+    - name: Rebuild and deploy backend container
+      env:
+        SSH_PRIVATE_KEY: ${{ secrets.SSH_PRIVATE_KEY }}
+        SSH_HOST: ${{ secrets.SSH_HOST }}
+        SSH_USER: ${{ secrets.SSH_USER }}
+```
+
+### Blue-Green Deployment SSH Steps
+- copy SSH details from repository secrets
+```yaml
+      run: |
+        echo "$SSH_PRIVATE_KEY" | tr -d '\r' > id_rsa
+        chmod 600 id_rsa
+        ssh -o StrictHostKeyChecking=no -i id_rsa $SSH_USER@$SSH_HOST << 'EOF'
+```
+- pull updated repo and stop the `backend-service-green` container
+```yaml
+          cd MapGuesser/
+          git pull origin main
+          docker compose stop backend-service-green
+```
+- rebuild `backend-service-green` with updated code (`-d` for detached)
+```yaml
+          docker compose up -d --build backend-service-green
+```
+- stop `backend-service-blue` container and force reload nginx configuration so it doesn't hang trying to access `backend-service-blue`
+```yaml
+          docker compose stop backend-service-blue
+          docker exec reverse-proxy nginx -s reload
+```
+- rebuild `backend-service blue` and reload nginx conf again
+```yaml
+          docker compose up -d --build backend-service-blue
+          docker exec reverse-proxy nginx -s reload
+        EOF
+```

--- a/.github/workflows/backend-service-cd.yml
+++ b/.github/workflows/backend-service-cd.yml
@@ -28,8 +28,10 @@ jobs:
         ssh -o StrictHostKeyChecking=no -i id_rsa $SSH_USER@$SSH_HOST << 'EOF'
           cd MapGuesser/
           git pull origin main
-          cd backend-service/
-          docker stop api
-          docker build -t mapguesser_api:latest . 
-          docker run -d --rm -p 3000:3000 --name api mapguesser_api:latest
+          docker compose stop backend-service-green
+          docker compose up -d --build backend-service-green
+          docker compose stop backend-service-blue
+          docker compose exec reverse-proxy nginx -s reload
+          docker compose up -d --build backend-service-blue
+          docker compose exec reverse-proxy nginx -s reload
         EOF

--- a/backend-service/README.md
+++ b/backend-service/README.md
@@ -8,11 +8,27 @@ npm start
 # server is running on port: 3000 (default)
 ```
 ### With Docker
+#### Running just the backend service
 `cd backend-service/`
 
 `docker build -t mapguesser_api:latest .`
 
 `docker run -d --rm -p 3000:3000 --name api mapguesser_api:latest`
+
+### With Docker Compose
+#### Running the backend service through the reverse-proxy
+
+From the root folder:
+
+`docker compose up --build`
+
+This will create a container for both the reverse proxy (Nginx), and the backend service.
+
+Nginx is listening on port 80 and at the `/api` prefix.
+
+So `curl localhost/api/health` will return "Ok"
+
+and `docker compose down` when you're done
 
 #### Notes
 - `-d` will run the container detached

--- a/backend-service/README.md
+++ b/backend-service/README.md
@@ -7,30 +7,17 @@ npm install
 npm start
 # server is running on port: 3000 (default)
 ```
-### With Docker
-#### Running just the backend service
-`cd backend-service/`
-
-`docker build -t mapguesser_api:latest .`
-
-`docker run -d --rm -p 3000:3000 --name api mapguesser_api:latest`
-
-### With Docker Compose
-#### Running the backend service through the reverse-proxy
+### With Docker (Compose)
 
 From the root folder:
+```bash
+docker compose up --build -d
+```
 
-`docker compose up --build`
-
-This will create a container for both the reverse proxy (Nginx), and the backend service.
+This will create containers for both the reverse proxy (nginx), and the backend service.
 
 Nginx is listening on port 80 and at the `/api` prefix.
 
 So `curl localhost/api/health` will return "Ok"
 
 and `docker compose down` when you're done
-
-#### Notes
-- `-d` will run the container detached
-- `--rm` will remove the container once it's stopped (waste not want not)
-- Specifying `--name api` is important for CD: the GitHub Actions workflow specifically uses this name to stop the currently running container before starting rebuilding and starting the new one

--- a/backend-service/nginx.conf
+++ b/backend-service/nginx.conf
@@ -1,0 +1,23 @@
+events {
+    worker_connections 1024;
+}
+
+http {
+    upstream backend {
+        server backend-service-blue:3000;
+        server backend-service-green:3000;
+    }
+
+    server {
+        listen 80;
+
+        location /api {
+            rewrite ^/api(.*)$ $1 break; # remove /api prefix from the ACTUAL request
+            proxy_pass http://backend;
+            proxy_set_header Host $host;
+            proxy_set_header X-Real-IP $remote_addr;
+            proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+            proxy_set_header X-Forwarded-Proto $scheme;
+        }
+    }
+}

--- a/compose.yml
+++ b/compose.yml
@@ -1,0 +1,22 @@
+services:
+  backend-service-blue:
+    build:
+      context: ./backend-service
+    environment:
+      - API_PORT=3000
+    
+  backend-service-green:
+    build:
+      context: ./backend-service
+    environment:
+      - API_PORT=3000
+
+  reverse-proxy:
+    image: nginx:alpine
+    ports:
+      - 80:80
+    volumes:
+      - ./backend-service/nginx.conf:/etc/nginx/nginx.conf
+    depends_on:
+      - backend-service-blue
+      - backend-service-green


### PR DESCRIPTION
- Blue-Green backend setup to approach true CD
- This won't work this first time because the workflow relies on the docker network already being created, see the backend-service/README.md
- Bonus: nginx will do some fun balancing between the two APIs, they don't take up much resources so I'm happy enough just to leave the two spinning
### TODO (if you want, lemme know and i'll change this from draft to ready )
- IMO we needn't bother because it's almost certainly easier to just SSH into the server and restart everything
- I can add another step that does a container healthcheck before shutting down the old container.
    - only thing is that would need a real bash script and not just the workflow, because we're effectively if/elsing
    - also we'd then have to manage an inconsistent state between the repo and what's actually deployed on the server
 