### PR TITLE
Remove Clerk authentication from multiplayer setup

### DIFF
--- a/backend-service/multiplayer-serivce/README.md
+++ b/backend-service/multiplayer-serivce/README.md
@@ -16,14 +16,14 @@ Simple health check endpoint that returns a status response.
 ```
 
 ### POST /create-game
-Creates a new multiplayer game. Requires authentication via Clerk.
-
-**Authentication:** Required (Clerk JWT token in `Authorization` header)
+Creates a new multiplayer game. The client supplies the host identity so the
+creator can be marked as the lobby host.
 
 **Request Body:**
 ```json
 {
-  "timer": 60000
+  "timer": 60000,
+  "hostId": "guest_123456"
 }
 ```
 
@@ -36,8 +36,7 @@ Creates a new multiplayer game. Requires authentication via Clerk.
 }
 ```
 
-**Error Responses:**
-- `401 Unauthorized`: Missing or invalid authentication token
+- `400 Bad Request`: Missing `hostId`
 
 ### GET /join-game/:code
 Resolves room data from a join code.
@@ -100,15 +99,6 @@ After connecting, clients should send a `player_join` message to register:
 
 ## Development
 
-**Add env vars**
-
-Create `.dev.vars` file in multiplayer-service directory root. Add keys:
-
-```bash
-CLERK_PUBLISHABLE_KEY=pk_test_...
-CLERK_SECRET_KEY=sk_test_...
-```
-
 **Run service**
 ```bash
 npm install
@@ -116,15 +106,7 @@ npm run dev
 # available at http://localhost:8788
 ```
 
-## Deployment 
-
-**Add env vars to Cloudflare**
-
-Run these commands and add the keys:
-```bash
-wrangler secret put CLERK_PUBLISHABLE_KEY
-wrangler secret put CLERK_SECRET_KEY
-```
+## Deployment
 
 **Deploy service**
 ```bash

--- a/backend-service/multiplayer-serivce/README.md
+++ b/backend-service/multiplayer-serivce/README.md
@@ -16,8 +16,7 @@ Simple health check endpoint that returns a status response.
 ```
 
 ### POST /create-game
-Creates a new multiplayer game. The client supplies the host identity so the
-creator can be marked as the lobby host.
+Creates a new multiplayer game. The client supplies the host identity so the creator can be marked as the lobby host.
 
 **Request Body:**
 ```json

--- a/backend-service/multiplayer-serivce/package-lock.json
+++ b/backend-service/multiplayer-serivce/package-lock.json
@@ -6,7 +6,6 @@
     "": {
       "name": "multiplayer-serivce",
       "dependencies": {
-        "@hono/clerk-auth": "^3.0.3",
         "hono": "^4.9.9"
       },
       "devDependencies": {
@@ -92,61 +91,6 @@
       "dev": true,
       "engines": {
         "node": ">=18"
-      }
-    },
-    "node_modules/@clerk/backend": {
-      "version": "2.17.0",
-      "resolved": "https://registry.npmjs.org/@clerk/backend/-/backend-2.17.0.tgz",
-      "integrity": "sha512-PyQJ1pIoqovf5ZH4lXus8bQ7N5dBmohBWPlzl2HxJklOU4YVFjBARNBqw28JitaQ8TgpLvLXffWFG8DpUpIgjg==",
-      "dependencies": {
-        "@clerk/shared": "^3.27.1",
-        "@clerk/types": "^4.90.0",
-        "cookie": "1.0.2",
-        "standardwebhooks": "^1.0.0",
-        "tslib": "2.8.1"
-      },
-      "engines": {
-        "node": ">=18.17.0"
-      }
-    },
-    "node_modules/@clerk/shared": {
-      "version": "3.27.1",
-      "resolved": "https://registry.npmjs.org/@clerk/shared/-/shared-3.27.1.tgz",
-      "integrity": "sha512-xvlc1LktFvVGt7T25Obg5vDyhGh9pVK8X976k7oGsqaJ9SWCdKVKj4cFIXh5bo0o7HkvJKdbz/gRl9GWk+IyoQ==",
-      "hasInstallScript": true,
-      "dependencies": {
-        "@clerk/types": "^4.90.0",
-        "dequal": "2.0.3",
-        "glob-to-regexp": "0.4.1",
-        "js-cookie": "3.0.5",
-        "std-env": "^3.9.0",
-        "swr": "2.3.4"
-      },
-      "engines": {
-        "node": ">=18.17.0"
-      },
-      "peerDependencies": {
-        "react": "^18.0.0 || ^19.0.0 || ^19.0.0-0",
-        "react-dom": "^18.0.0 || ^19.0.0 || ^19.0.0-0"
-      },
-      "peerDependenciesMeta": {
-        "react": {
-          "optional": true
-        },
-        "react-dom": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@clerk/types": {
-      "version": "4.90.0",
-      "resolved": "https://registry.npmjs.org/@clerk/types/-/types-4.90.0.tgz",
-      "integrity": "sha512-AnXeCkyFdM+3icdeKElajVKV73IvlQ6eeWTaLG700CzL+Zw9iD2YV4t8qAhNhwo0FFtkcI9EKDblw6G9Rn1Onw==",
-      "dependencies": {
-        "csstype": "3.1.3"
-      },
-      "engines": {
-        "node": ">=18.17.0"
       }
     },
     "node_modules/@cloudflare/kv-asset-handler": {
@@ -682,21 +626,6 @@
       ],
       "engines": {
         "node": ">=18"
-      }
-    },
-    "node_modules/@hono/clerk-auth": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/@hono/clerk-auth/-/clerk-auth-3.0.3.tgz",
-      "integrity": "sha512-N671mw3ulvxqxY8ou8D8ojVT7EKljXE6RjdC2egWExMcrQAglMSTvqvU096MbOT5zvWtc8QMo3SKiyTXn30BrQ==",
-      "dependencies": {
-        "@clerk/backend": "^2.4.1",
-        "@clerk/types": "^4.64.0"
-      },
-      "engines": {
-        "node": ">=16.x.x"
-      },
-      "peerDependencies": {
-        "hono": ">=3.0.0"
       }
     },
     "node_modules/@img/sharp-darwin-arm64": {

--- a/backend-service/multiplayer-serivce/package.json
+++ b/backend-service/multiplayer-serivce/package.json
@@ -10,7 +10,6 @@
     "test:coverage": "vitest run --coverage"
   },
   "dependencies": {
-    "@hono/clerk-auth": "^3.0.3",
     "hono": "^4.9.9"
   },
   "devDependencies": {

--- a/backend-service/multiplayer-serivce/src/durable-objects/GameRoom.ts
+++ b/backend-service/multiplayer-serivce/src/durable-objects/GameRoom.ts
@@ -83,10 +83,13 @@ export class GameRoom extends DurableObject {
 		// Only include WebSockets that are in OPEN state (readyState === 1)
 		// This filters out connections that are CLOSING (2) or CLOSED (3)
 		const activeWebSockets = webSockets.filter(ws => ws.readyState === WebSocket.OPEN);
-		return activeWebSockets.map(ws => {
-			const player = ws.deserializeAttachment() as Player | undefined;
-			return player || { playerId: 'unknown', playerName: 'Unknown', isGuest: true };
-		});
+		return activeWebSockets
+			.map(ws => {
+				const player = ws.deserializeAttachment() as Player | undefined;
+				return player || { playerId: 'unknown', playerName: 'Unknown', isGuest: true };
+			})
+			// Filter out unknown players - these are connections that haven't sent player_join yet
+			.filter(player => player.playerId !== 'unknown');
 	}
 
 	private broadcastPlayerList(): void {

--- a/backend-service/multiplayer-serivce/src/durable-objects/GameRoom.ts
+++ b/backend-service/multiplayer-serivce/src/durable-objects/GameRoom.ts
@@ -11,9 +11,45 @@ export class GameRoom extends DurableObject {
 	}
 
 	/**
-	 * Handle incoming HTTP requests (WebSocket upgrades)
+	 * Initialize the game room with metadata
+	 */
+	async initialize(gameOwnerId: string, timer: number): Promise<void> {
+		await this.ctx.storage.put('gameOwnerId', gameOwnerId);
+		await this.ctx.storage.put('timer', timer);
+	}
+
+	/**
+	 * Get game metadata
+	 */
+	async getMetadata(): Promise<{ gameOwnerId: string | null; timer: number | null }> {
+		const gameOwnerId = await this.ctx.storage.get<string>('gameOwnerId');
+		const timer = await this.ctx.storage.get<number>('timer');
+		return { gameOwnerId: gameOwnerId ?? null, timer: timer ?? null };
+	}
+
+	/**
+	 * Handle incoming HTTP requests (WebSocket upgrades and HTTP methods)
 	 */
 	async fetch(request: Request): Promise<Response> {
+		const url = new URL(request.url);
+
+		// Handle HTTP methods for game room management
+		if (request.method === 'POST' && url.pathname === '/initialize') {
+			const body = await request.json() as { gameOwnerId: string; timer: number };
+			await this.initialize(body.gameOwnerId, body.timer);
+			return new Response(JSON.stringify({ success: true }), {
+				headers: { 'Content-Type': 'application/json' }
+			});
+		}
+
+		if (request.method === 'GET' && url.pathname === '/metadata') {
+			const metadata = await this.getMetadata();
+			return new Response(JSON.stringify(metadata), {
+				headers: { 'Content-Type': 'application/json' }
+			});
+		}
+
+		// Handle WebSocket upgrade
 		const upgradeHeader = request.headers.get('Upgrade');
 		if (upgradeHeader !== 'websocket') {
 			return new Response('Expected WebSocket', { status: 426 });

--- a/backend-service/multiplayer-serivce/src/index.ts
+++ b/backend-service/multiplayer-serivce/src/index.ts
@@ -40,28 +40,28 @@ app.get('/health', (c) => {
  * @description Creates a new multiplayer game (host identity supplied by client)
  */
 app.post('/create-game', async (c) => {
-        const { timer, hostId } = await c.req.json();
+	const { timer, hostId } = await c.req.json();
 
-        if (!hostId) {
-                return c.json({ error: 'Host identity required' }, 400);
-        }
+	if (!hostId) {
+		return c.json({ error: 'Host identity required' }, 400);
+	}
 
-        const gameCode = generateGameCode();
+	const gameCode = generateGameCode();
 
-        // Initialize the GameRoom with host information
-        const id = c.env.GAME_ROOM.idFromName(gameCode);
-        const stub = c.env.GAME_ROOM.get(id);
-        await stub.fetch('http://internal/initialize', {
-                method: 'POST',
-                body: JSON.stringify({ gameOwnerId: hostId, timer }),
-                headers: { 'Content-Type': 'application/json' }
-        });
+	// Initialize the GameRoom with host information
+	const id = c.env.GAME_ROOM.idFromName(gameCode);
+	const stub = c.env.GAME_ROOM.get(id);
+	await stub.fetch('http://internal/initialize', {
+		method: 'POST',
+		body: JSON.stringify({ gameOwnerId: hostId, timer }),
+		headers: { 'Content-Type': 'application/json' }
+	});
 
-        return c.json({
-                gameCode,
-                timer,
-                gameOwnerId: hostId,
-        });
+	return c.json({
+		gameCode,
+		timer,
+		gameOwnerId: hostId,
+	});
 })
 
 /**

--- a/backend-service/multiplayer-serivce/src/index.ts
+++ b/backend-service/multiplayer-serivce/src/index.ts
@@ -48,6 +48,15 @@ app.post('/create-game', async (c) => {
 
         const gameCode = generateGameCode();
 
+        // Initialize the GameRoom with host information
+        const id = c.env.GAME_ROOM.idFromName(gameCode);
+        const stub = c.env.GAME_ROOM.get(id);
+        await stub.fetch('http://internal/initialize', {
+                method: 'POST',
+                body: JSON.stringify({ gameOwnerId: hostId, timer }),
+                headers: { 'Content-Type': 'application/json' }
+        });
+
         return c.json({
                 gameCode,
                 timer,
@@ -63,13 +72,20 @@ app.get('/join-game/:code', async (c) => {
 	const raw = c.req.param('code') ?? '';
 	const code = raw.trim().toUpperCase();
 
+	// Fetch metadata from the GameRoom
+	const id = c.env.GAME_ROOM.idFromName(code);
+	const stub = c.env.GAME_ROOM.get(id);
+	const metadataResponse = await stub.fetch('http://internal/metadata', {
+		method: 'GET'
+	});
+	const metadata = await metadataResponse.json() as { gameOwnerId: string | null; timer: number | null };
+
 	return c.json({
 		roomId: code,
 		status: "...",
 		expiresAt: "...",
 		wsUrl: "...",
-		// Harcode this for now
-		gameOwnerId: "user_12345678"
+		gameOwnerId: metadata.gameOwnerId
 	});
 })
 

--- a/backend-service/multiplayer-serivce/src/index.ts
+++ b/backend-service/multiplayer-serivce/src/index.ts
@@ -1,6 +1,5 @@
 import { Hono } from 'hono'
 import { cors } from 'hono/cors'
-import { clerkMiddleware, getAuth } from '@hono/clerk-auth'
 import { GameRoom } from './durable-objects/GameRoom'
 import { Bindings } from './index.types'
 import { generateGameCode } from './multiplayerUtils'
@@ -38,23 +37,22 @@ app.get('/health', (c) => {
 
 /**
  * POST /create-game
- * @description Creates a new multiplayer game (requires authentication)
+ * @description Creates a new multiplayer game (host identity supplied by client)
  */
-app.post('/create-game', clerkMiddleware(), async (c) => {
-	const auth = getAuth(c);
+app.post('/create-game', async (c) => {
+        const { timer, hostId } = await c.req.json();
 
-	if (!auth?.userId) {
-		return c.json({ error: 'Unauthorized' }, 401);
-	}
+        if (!hostId) {
+                return c.json({ error: 'Host identity required' }, 400);
+        }
 
-	const { timer } = await c.req.json();
-	const gameCode = generateGameCode();
+        const gameCode = generateGameCode();
 
-	return c.json({
-		gameCode,
-		timer,
-		gameOwnerId: auth.userId,
-	});
+        return c.json({
+                gameCode,
+                timer,
+                gameOwnerId: hostId,
+        });
 })
 
 /**

--- a/backend-service/multiplayer-serivce/src/index.types.ts
+++ b/backend-service/multiplayer-serivce/src/index.types.ts
@@ -1,7 +1,5 @@
 type Bindings = {
-	CLERK_PUBLISHABLE_KEY: string;
-	CLERK_SECRET_KEY: string;
-	GAME_ROOM: DurableObjectNamespace;
+        GAME_ROOM: DurableObjectNamespace;
 }
 
 export {

--- a/backend-service/multiplayer-serivce/src/index.types.ts
+++ b/backend-service/multiplayer-serivce/src/index.types.ts
@@ -1,5 +1,5 @@
 type Bindings = {
-        GAME_ROOM: DurableObjectNamespace;
+    GAME_ROOM: DurableObjectNamespace;
 }
 
 export {

--- a/backend-service/multiplayer-serivce/src/tests/index.test.ts
+++ b/backend-service/multiplayer-serivce/src/tests/index.test.ts
@@ -17,7 +17,6 @@ const mockEnv = {
 
 				if (options?.method === 'GET' && urlObj.pathname === '/metadata') {
 					// Return mock metadata - in real scenario this would be from storage
-					const body = options?.method === 'POST' ? await new Request(url, options).json() : null;
 					return new Response(JSON.stringify({
 						gameOwnerId: 'guest_123',
 						timer: 60
@@ -46,38 +45,38 @@ describe('GET /health', () => {
 })
 
 describe('POST /create-game', () => {
-        test('should return 400 when host identity missing', async () => {
-                const timer = 60
-                const res = await app.request('/create-game', {
-                        method: 'POST',
-                        body: JSON.stringify({ timer }),
-                        headers: {
-                                'Content-Type': 'application/json',
-                        },
-                }, mockEnv)
+	test('should return 400 when host identity missing', async () => {
+		const timer = 60
+		const res = await app.request('/create-game', {
+			method: 'POST',
+			body: JSON.stringify({ timer }),
+			headers: {
+					'Content-Type': 'application/json',
+			},
+		}, mockEnv)
 
-                expect(res.status).toBe(400)
-                const json = await res.json()
-                expect(json).toHaveProperty('error', 'Host identity required')
-        })
+		expect(res.status).toBe(400)
+		const json = await res.json()
+		expect(json).toHaveProperty('error', 'Host identity required')
+	})
 
-        test('should create a game with timer and return gameCode when host identity provided', async () => {
-                const timer = 60
-                const hostId = 'guest_123'
-                const res = await app.request('/create-game', {
-                        method: 'POST',
-                        body: JSON.stringify({ timer, hostId }),
-                        headers: {
-                                'Content-Type': 'application/json',
-                        },
-                }, mockEnv)
+	test('should create a game with timer and return gameCode when host identity provided', async () => {
+		const timer = 60
+		const hostId = 'guest_123'
+		const res = await app.request('/create-game', {
+			method: 'POST',
+			body: JSON.stringify({ timer, hostId }),
+			headers: {
+					'Content-Type': 'application/json',
+			},
+		}, mockEnv)
 
-                expect(res.status).toBe(200)
-                const json = await res.json()
-                expect(json).toHaveProperty('gameCode')
-                expect(json).toHaveProperty('timer', timer)
-                expect(json).toHaveProperty('gameOwnerId', hostId)
-        })
+		expect(res.status).toBe(200)
+		const json = await res.json()
+		expect(json).toHaveProperty('gameCode')
+		expect(json).toHaveProperty('timer', timer)
+		expect(json).toHaveProperty('gameOwnerId', hostId)
+	})
 })
 
 describe('GET /join-game', () => {

--- a/backend-service/multiplayer-serivce/src/tests/index.test.ts
+++ b/backend-service/multiplayer-serivce/src/tests/index.test.ts
@@ -1,19 +1,5 @@
-import { describe, test, expect, vi } from 'vitest'
+import { describe, test, expect } from 'vitest'
 import app from '../index'
-
-// Mock the Clerk auth module
-vi.mock('@hono/clerk-auth', () => ({
-	clerkMiddleware: () => {
-		return async (c: any, next: any) => {
-			// Store mock auth data in context for getAuth to retrieve
-			c.set('clerk', { userId: c.req.header('x-mock-user-id') || null });
-			await next();
-		}
-	},
-	getAuth: (c: any) => {
-		return c.get('clerk');
-	},
-}))
 
 describe('GET /health', () => {
 	test('should return status ok', async () => {
@@ -25,38 +11,38 @@ describe('GET /health', () => {
 })
 
 describe('POST /create-game', () => {
-	test('should return 401 when no auth provided', async () => {
-		const timer = 60
-		const res = await app.request('/create-game', {
-			method: 'POST',
-			body: JSON.stringify({ timer }),
-			headers: {
-				'Content-Type': 'application/json',
-			},
-		})
+        test('should return 400 when host identity missing', async () => {
+                const timer = 60
+                const res = await app.request('/create-game', {
+                        method: 'POST',
+                        body: JSON.stringify({ timer }),
+                        headers: {
+                                'Content-Type': 'application/json',
+                        },
+                })
 
-		expect(res.status).toBe(401)
-		const json = await res.json()
-		expect(json).toHaveProperty('error', 'Unauthorized')
-	})
+                expect(res.status).toBe(400)
+                const json = await res.json()
+                expect(json).toHaveProperty('error', 'Host identity required')
+        })
 
-	test('should create a game with timer and return gameCode when authenticated', async () => {
-		const timer = 60
-		const res = await app.request('/create-game', {
-			method: 'POST',
-			body: JSON.stringify({ timer }),
-			headers: {
-				'Content-Type': 'application/json',
-				'x-mock-user-id': 'user_123',
-			},
-		})
+        test('should create a game with timer and return gameCode when host identity provided', async () => {
+                const timer = 60
+                const hostId = 'guest_123'
+                const res = await app.request('/create-game', {
+                        method: 'POST',
+                        body: JSON.stringify({ timer, hostId }),
+                        headers: {
+                                'Content-Type': 'application/json',
+                        },
+                })
 
-		expect(res.status).toBe(200)
-		const json = await res.json()
-		expect(json).toHaveProperty('gameCode')
-		expect(json).toHaveProperty('timer', timer)
-		expect(json).toHaveProperty('gameOwnerId', 'user_123')
-	})
+                expect(res.status).toBe(200)
+                const json = await res.json()
+                expect(json).toHaveProperty('gameCode')
+                expect(json).toHaveProperty('timer', timer)
+                expect(json).toHaveProperty('gameOwnerId', hostId)
+        })
 })
 
 describe('GET /join-game', () => {

--- a/backend-service/multiplayer-serivce/src/tests/index.test.ts
+++ b/backend-service/multiplayer-serivce/src/tests/index.test.ts
@@ -1,5 +1,40 @@
-import { describe, test, expect } from 'vitest'
+import { describe, test, expect, beforeEach, vi } from 'vitest'
 import app from '../index'
+
+// Mock environment with GAME_ROOM Durable Object
+const mockEnv = {
+	GAME_ROOM: {
+		idFromName: vi.fn((name: string) => name),
+		get: vi.fn(() => ({
+			fetch: vi.fn(async (url: string, options?: RequestInit) => {
+				const urlObj = new URL(url);
+
+				if (options?.method === 'POST' && urlObj.pathname === '/initialize') {
+					return new Response(JSON.stringify({ success: true }), {
+						headers: { 'Content-Type': 'application/json' }
+					});
+				}
+
+				if (options?.method === 'GET' && urlObj.pathname === '/metadata') {
+					// Return mock metadata - in real scenario this would be from storage
+					const body = options?.method === 'POST' ? await new Request(url, options).json() : null;
+					return new Response(JSON.stringify({
+						gameOwnerId: 'guest_123',
+						timer: 60
+					}), {
+						headers: { 'Content-Type': 'application/json' }
+					});
+				}
+
+				return new Response('Not found', { status: 404 });
+			})
+		}))
+	}
+};
+
+beforeEach(() => {
+	vi.clearAllMocks();
+});
 
 describe('GET /health', () => {
 	test('should return status ok', async () => {
@@ -19,7 +54,7 @@ describe('POST /create-game', () => {
                         headers: {
                                 'Content-Type': 'application/json',
                         },
-                })
+                }, mockEnv)
 
                 expect(res.status).toBe(400)
                 const json = await res.json()
@@ -35,7 +70,7 @@ describe('POST /create-game', () => {
                         headers: {
                                 'Content-Type': 'application/json',
                         },
-                })
+                }, mockEnv)
 
                 expect(res.status).toBe(200)
                 const json = await res.json()
@@ -47,10 +82,10 @@ describe('POST /create-game', () => {
 
 describe('GET /join-game', () => {
 	test('should return roomId in object', async () => {
-		const res = await app.request('/join-game/abcde')
+		const res = await app.request('/join-game/abcde', {}, mockEnv)
 		expect(res.status).toBe(200)
 		const json = await res.json()
 		expect(json).toHaveProperty('roomId', 'ABCDE')
-		expect(json).toHaveProperty('gameOwnerId', 'user_12345678')
+		expect(json).toHaveProperty('gameOwnerId', 'guest_123')
 	})
 })

--- a/frontend-service/package-lock.json
+++ b/frontend-service/package-lock.json
@@ -8,7 +8,6 @@
       "name": "frontend-service",
       "version": "1.0.0",
       "dependencies": {
-        "@clerk/clerk-react": "^5.49.0",
         "@radix-ui/react-progress": "^1.1.6",
         "@radix-ui/react-slider": "^1.3.4",
         "@radix-ui/react-slot": "^1.2.1",
@@ -2078,68 +2077,6 @@
       "integrity": "sha512-snXIGNiZpqjno3XYQN2lbBB+05hsQR/LSttbtIW1c0gmZ7Kh/DIo0YrxlDxCDulAMFPFM8J+4voLwvYepSj3sw==",
       "bin": {
         "partytown": "bin/partytown.cjs"
-      }
-    },
-    "node_modules/@clerk/clerk-react": {
-      "version": "5.49.0",
-      "resolved": "https://registry.npmjs.org/@clerk/clerk-react/-/clerk-react-5.49.0.tgz",
-      "integrity": "sha512-YdprkVMefaYv6LIbO0LpVzcYabXXpujWA/TfBHxsZVrYnrX51tRvBq2ihbNPsttGMYtqyCIpp6wkmqm116aR0g==",
-      "dependencies": {
-        "@clerk/shared": "^3.27.0",
-        "@clerk/types": "^4.89.0",
-        "tslib": "2.8.1"
-      },
-      "engines": {
-        "node": ">=18.17.0"
-      },
-      "peerDependencies": {
-        "react": "^18.0.0 || ^19.0.0 || ^19.0.0-0",
-        "react-dom": "^18.0.0 || ^19.0.0 || ^19.0.0-0"
-      }
-    },
-    "node_modules/@clerk/clerk-react/node_modules/tslib": {
-      "version": "2.8.1",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
-      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="
-    },
-    "node_modules/@clerk/shared": {
-      "version": "3.27.0",
-      "resolved": "https://registry.npmjs.org/@clerk/shared/-/shared-3.27.0.tgz",
-      "integrity": "sha512-dVtmZ3+g/QrofBfnAa/SRDS+8tC58nmDT2+4+0OsTedq6F2u6rETTYZIn9P63U3BaRII7ItMFW4c8WgZXOnSIw==",
-      "hasInstallScript": true,
-      "dependencies": {
-        "@clerk/types": "^4.89.0",
-        "dequal": "2.0.3",
-        "glob-to-regexp": "0.4.1",
-        "js-cookie": "3.0.5",
-        "std-env": "^3.9.0",
-        "swr": "2.3.4"
-      },
-      "engines": {
-        "node": ">=18.17.0"
-      },
-      "peerDependencies": {
-        "react": "^18.0.0 || ^19.0.0 || ^19.0.0-0",
-        "react-dom": "^18.0.0 || ^19.0.0 || ^19.0.0-0"
-      },
-      "peerDependenciesMeta": {
-        "react": {
-          "optional": true
-        },
-        "react-dom": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@clerk/types": {
-      "version": "4.89.0",
-      "resolved": "https://registry.npmjs.org/@clerk/types/-/types-4.89.0.tgz",
-      "integrity": "sha512-4pT8s/f05C3w1ggRvF12Vr+Ms8GisVBNoWG56znGuofoQ4pzLhJJTU6daVCxTjkPf30IlYtQfoAUaKjXDwH/rw==",
-      "dependencies": {
-        "csstype": "3.1.3"
-      },
-      "engines": {
-        "node": ">=18.17.0"
       }
     },
     "node_modules/@esbuild/aix-ppc64": {

--- a/frontend-service/package.json
+++ b/frontend-service/package.json
@@ -19,7 +19,6 @@
     "test": "vitest && playwright test"
   },
   "dependencies": {
-    "@clerk/clerk-react": "^5.49.0",
     "@radix-ui/react-progress": "^1.1.6",
     "@radix-ui/react-slider": "^1.3.4",
     "@radix-ui/react-slot": "^1.2.1",

--- a/frontend-service/src/components/game-setup-modal/Lobby.tsx
+++ b/frontend-service/src/components/game-setup-modal/Lobby.tsx
@@ -1,5 +1,4 @@
-import React, { useState, useEffect, useRef } from 'react';
-import { useUser } from '@clerk/clerk-react';
+import React, { useEffect, useRef } from 'react';
 import { Paragraph } from '../typography/Typography';
 import { Button } from '../ui/button';
 import { useMultiplayerStore } from '../../store/multiplayerStore';
@@ -10,38 +9,37 @@ import LobbyGameCode from '../lobby/LobbyGameCode';
 import LobbyPlayersList from '../lobby/LobbyPlayersList';
 
 const Lobby = () => {
-	const { user, isSignedIn, isLoaded } = useUser();
-	const { gameData, players, setPlayers } = useMultiplayerStore();
-	const hasJoinedRef = useRef(false);
+        const { gameData, players, setPlayers } = useMultiplayerStore();
+        const hasJoinedRef = useRef(false);
+        const playerIdentityRef = useRef(getPlayerIdentity());
 
-	const hash = window.location.hash;
-	const gameCode = hash.replace('#lobby-', '');
+        const hash = window.location.hash;
+        const gameCode = hash.replace('#lobby-', '');
 
-	const isGameOwner = isSignedIn && user?.id === gameData?.gameOwnerId;
+        const isGameOwner = gameData?.gameOwnerId === playerIdentityRef.current.playerId;
 
-	const { connectionStatus, sendMessage } = useGameRoom({ gameCode, setPlayers });
+        const { connectionStatus, sendMessage } = useGameRoom({ gameCode, setPlayers });
 
-	// Send player join message when connected (only once per connection)
-	// Wait for Clerk to load before identifying the user
-	useEffect(() => {
-		if (connectionStatus === ConnectionStatus.CONNECTED && isLoaded && !hasJoinedRef.current) {
-			const identity = getPlayerIdentity(isSignedIn ? user : undefined);
+        // Send player join message when connected (only once per connection)
+        useEffect(() => {
+                if (connectionStatus === ConnectionStatus.CONNECTED && !hasJoinedRef.current) {
+                        const identity = playerIdentityRef.current;
 
-			sendMessage({
-				type: 'player_join',
-				...identity,
-			});
+                        sendMessage({
+                                type: 'player_join',
+                                ...identity,
+                        });
 
-			hasJoinedRef.current = true;
-		} else if (connectionStatus === ConnectionStatus.DISCONNECTED) {
-			// Reset when disconnected so we can rejoin if reconnecting
-			hasJoinedRef.current = false;
-		}
-	}, [connectionStatus, isLoaded, isSignedIn, user]);
+                        hasJoinedRef.current = true;
+                } else if (connectionStatus === ConnectionStatus.DISCONNECTED) {
+                        // Reset when disconnected so we can rejoin if reconnecting
+                        hasJoinedRef.current = false;
+                }
+        }, [connectionStatus, sendMessage]);
 
-	const handleStartGame = () => {
-		sendMessage({
-			type: 'game_start',
+        const handleStartGame = () => {
+                sendMessage({
+                        type: 'game_start',
 		});
 	};
 

--- a/frontend-service/src/components/game-setup-modal/Lobby.tsx
+++ b/frontend-service/src/components/game-setup-modal/Lobby.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useRef } from 'react';
+import React, { useEffect, useRef, useState } from 'react';
 import { Paragraph } from '../typography/Typography';
 import { Button } from '../ui/button';
 import { useMultiplayerStore } from '../../store/multiplayerStore';
@@ -7,14 +7,41 @@ import { getPlayerIdentity } from '../../utils/guestIdentityUtils';
 import { ConnectionStatus } from '../../objects/connectionStatuses';
 import LobbyGameCode from '../lobby/LobbyGameCode';
 import LobbyPlayersList from '../lobby/LobbyPlayersList';
+import { MULTIPLAYER_SERVICE_API_URL } from '../../objects/endpoints';
+import type { JoinGameResponse } from '../../types/MultiplayerServiceApiResponse.types';
 
 const Lobby = () => {
-        const { gameData, players, setPlayers } = useMultiplayerStore();
+        const { gameData, players, setPlayers, setGameData } = useMultiplayerStore();
         const hasJoinedRef = useRef(false);
         const playerIdentityRef = useRef(getPlayerIdentity());
+        const [isFetchingMetadata, setIsFetchingMetadata] = useState(false);
 
         const hash = window.location.hash;
         const gameCode = hash.replace('#lobby-', '');
+
+        // Fetch game metadata if we don't have it (e.g., direct URL navigation)
+        useEffect(() => {
+                const fetchGameMetadata = async () => {
+                        if (!gameData && gameCode && !isFetchingMetadata) {
+                                setIsFetchingMetadata(true);
+                                try {
+                                        const response = await fetch(`${MULTIPLAYER_SERVICE_API_URL}/join-game/${gameCode}`);
+                                        const data = await response.json() as JoinGameResponse;
+                                        setGameData({
+                                                gameCode: data.roomId,
+                                                timer: 0,
+                                                gameOwnerId: data.gameOwnerId,
+                                        });
+                                } catch (error) {
+                                        console.error('Failed to fetch game metadata:', error);
+                                } finally {
+                                        setIsFetchingMetadata(false);
+                                }
+                        }
+                };
+
+                fetchGameMetadata();
+        }, [gameData, gameCode, isFetchingMetadata, setGameData]);
 
         const isGameOwner = gameData?.gameOwnerId === playerIdentityRef.current.playerId;
 

--- a/frontend-service/src/components/game-setup-modal/Lobby.tsx
+++ b/frontend-service/src/components/game-setup-modal/Lobby.tsx
@@ -11,62 +11,62 @@ import { MULTIPLAYER_SERVICE_API_URL } from '../../objects/endpoints';
 import type { JoinGameResponse } from '../../types/MultiplayerServiceApiResponse.types';
 
 const Lobby = () => {
-        const { gameData, players, setPlayers, setGameData } = useMultiplayerStore();
-        const hasJoinedRef = useRef(false);
-        const playerIdentityRef = useRef(getPlayerIdentity());
-        const [isFetchingMetadata, setIsFetchingMetadata] = useState(false);
+	const { gameData, players, setPlayers, setGameData } = useMultiplayerStore();
+	const hasJoinedRef = useRef(false);
+	const playerIdentityRef = useRef(getPlayerIdentity());
+	const [isFetchingMetadata, setIsFetchingMetadata] = useState(false);
 
-        const hash = window.location.hash;
-        const gameCode = hash.replace('#lobby-', '');
+	const hash = window.location.hash;
+	const gameCode = hash.replace('#lobby-', '');
 
-        // Fetch game metadata if we don't have it (e.g., direct URL navigation)
-        useEffect(() => {
-                const fetchGameMetadata = async () => {
-                        if (!gameData && gameCode && !isFetchingMetadata) {
-                                setIsFetchingMetadata(true);
-                                try {
-                                        const response = await fetch(`${MULTIPLAYER_SERVICE_API_URL}/join-game/${gameCode}`);
-                                        const data = await response.json() as JoinGameResponse;
-                                        setGameData({
-                                                gameCode: data.roomId,
-                                                timer: 0,
-                                                gameOwnerId: data.gameOwnerId,
-                                        });
-                                } catch (error) {
-                                        console.error('Failed to fetch game metadata:', error);
-                                } finally {
-                                        setIsFetchingMetadata(false);
-                                }
-                        }
-                };
+	// Fetch game metadata if we don't have it (e.g., direct URL navigation)
+	useEffect(() => {
+		const fetchGameMetadata = async () => {
+			if (!gameData && gameCode && !isFetchingMetadata) {
+				setIsFetchingMetadata(true);
+				try {
+					const response = await fetch(`${MULTIPLAYER_SERVICE_API_URL}/join-game/${gameCode}`);
+					const data = await response.json() as JoinGameResponse;
+					setGameData({
+						gameCode: data.roomId,
+						timer: 0,
+						gameOwnerId: data.gameOwnerId,
+					});
+				} catch (error) {
+					console.error('Failed to fetch game metadata:', error);
+				} finally {
+					setIsFetchingMetadata(false);
+				}
+			}
+		};
 
-                fetchGameMetadata();
-        }, [gameData, gameCode, isFetchingMetadata, setGameData]);
+		fetchGameMetadata();
+	}, [gameData, gameCode, isFetchingMetadata, setGameData]);
 
-        const isGameOwner = gameData?.gameOwnerId === playerIdentityRef.current.playerId;
+	const isGameOwner = gameData?.gameOwnerId === playerIdentityRef.current.playerId;
 
-        const { connectionStatus, sendMessage } = useGameRoom({ gameCode, setPlayers });
+	const { connectionStatus, sendMessage } = useGameRoom({ gameCode, setPlayers });
 
-        // Send player join message when connected (only once per connection)
-        useEffect(() => {
-                if (connectionStatus === ConnectionStatus.CONNECTED && !hasJoinedRef.current) {
-                        const identity = playerIdentityRef.current;
+	// Send player join message when connected (only once per connection)
+	useEffect(() => {
+		if (connectionStatus === ConnectionStatus.CONNECTED && !hasJoinedRef.current) {
+			const identity = playerIdentityRef.current;
 
-                        sendMessage({
-                                type: 'player_join',
-                                ...identity,
-                        });
+			sendMessage({
+				type: 'player_join',
+				...identity,
+			});
 
-                        hasJoinedRef.current = true;
-                } else if (connectionStatus === ConnectionStatus.DISCONNECTED) {
-                        // Reset when disconnected so we can rejoin if reconnecting
-                        hasJoinedRef.current = false;
-                }
-        }, [connectionStatus, sendMessage]);
+			hasJoinedRef.current = true;
+		} else if (connectionStatus === ConnectionStatus.DISCONNECTED) {
+			// Reset when disconnected so we can rejoin if reconnecting
+			hasJoinedRef.current = false;
+		}
+	}, [connectionStatus, sendMessage]);
 
-        const handleStartGame = () => {
-                sendMessage({
-                        type: 'game_start',
+	const handleStartGame = () => {
+		sendMessage({
+			type: 'game_start',
 		});
 	};
 

--- a/frontend-service/src/components/game-setup-modal/Lobby.tsx
+++ b/frontend-service/src/components/game-setup-modal/Lobby.tsx
@@ -41,7 +41,7 @@ const Lobby = () => {
 		};
 
 		fetchGameMetadata();
-	}, [gameData, gameCode, isFetchingMetadata, setGameData]);
+	}, []);
 
 	const isGameOwner = gameData?.gameOwnerId === playerIdentityRef.current.playerId;
 

--- a/frontend-service/src/components/game-setup-modal/SelectGameModeMenu.tsx
+++ b/frontend-service/src/components/game-setup-modal/SelectGameModeMenu.tsx
@@ -1,28 +1,17 @@
 import React from 'react'
-import { useAuth, useClerk } from '@clerk/clerk-react'
-import { GAME_SETUP_STEPS, gameModeCards } from '../../objects/gameSetupConsts'
+import { gameModeCards } from '../../objects/gameSetupConsts'
 import GameModeCard from './GameModeCard'
 import type { GameModeCardType } from '../../types/GameSetupModal.types'
 
 export default function SelectGameModeMenu() {
-	const { isSignedIn } = useAuth();
-	const { openSignIn } = useClerk();
+        const handleCardClick = (card: GameModeCardType) => {
+                if (!card.enabled) return;
 
-	const handleCardClick = (card: GameModeCardType) => {
-		if (!card.enabled) return;
-		
-		if (card.id === GAME_SETUP_STEPS.START_GAME) {
-			if (!isSignedIn) {
-				openSignIn();
-				return;
-			}
-		}
-		
-		window.location.hash = card.fragment;
-	};
+                window.location.hash = card.fragment;
+        };
 
-	return (
-		<div className="w-full">
+        return (
+                <div className="w-full">
 			<div className="grid grid-cols-1 md:grid-cols-3 gap-4 max-w-4xl mx-auto">
 				{gameModeCards.map((card) => (
 					<GameModeCard

--- a/frontend-service/src/components/game-setup-modal/SelectGameModeMenu.tsx
+++ b/frontend-service/src/components/game-setup-modal/SelectGameModeMenu.tsx
@@ -4,14 +4,14 @@ import GameModeCard from './GameModeCard'
 import type { GameModeCardType } from '../../types/GameSetupModal.types'
 
 export default function SelectGameModeMenu() {
-        const handleCardClick = (card: GameModeCardType) => {
-                if (!card.enabled) return;
+	const handleCardClick = (card: GameModeCardType) => {
+		if (!card.enabled) return;
 
-                window.location.hash = card.fragment;
-        };
+		window.location.hash = card.fragment;
+	};
 
-        return (
-                <div className="w-full">
+	return (
+		<div className="w-full">
 			<div className="grid grid-cols-1 md:grid-cols-3 gap-4 max-w-4xl mx-auto">
 				{gameModeCards.map((card) => (
 					<GameModeCard

--- a/frontend-service/src/components/game-setup-modal/StartMultiplayerGameSetup.tsx
+++ b/frontend-service/src/components/game-setup-modal/StartMultiplayerGameSetup.tsx
@@ -11,49 +11,49 @@ import { getPlayerIdentity } from '../../utils/guestIdentityUtils';
 
 
 const StartMultiPlayerGameSetup = () => {
-        const [timer, setTimer] = useState(0);
-        const [shouldFetch, setShouldFetch] = useState(false);
-        const { setGameData } = useMultiplayerStore();
-        const playerIdentityRef = useRef(getPlayerIdentity());
+	const [timer, setTimer] = useState(0);
+	const [shouldFetch, setShouldFetch] = useState(false);
+	const { setGameData } = useMultiplayerStore();
+	const playerIdentityRef = useRef(getPlayerIdentity());
 
-        const { data, isPending, error } = useFetch<CreateGameResponse>(
-                `${MULTIPLAYER_SERVICE_API_URL}/create-game`,
-                {
-                        method: 'POST',
-                        headers: {
-                                'Content-Type': 'application/json',
-                        },
-                        body: JSON.stringify({
-                                timer,
-                                hostId: playerIdentityRef.current.playerId,
-                        }),
-                        enabled: shouldFetch,
-                }
-        );
+	const { data, isPending, error } = useFetch<CreateGameResponse>(
+		`${MULTIPLAYER_SERVICE_API_URL}/create-game`,
+		{
+			method: 'POST',
+			headers: {
+				'Content-Type': 'application/json',
+			},
+			body: JSON.stringify({
+				timer,
+				hostId: playerIdentityRef.current.playerId,
+			}),
+			enabled: shouldFetch,
+		}
+	);
 
-        useEffect(() => {
-                if (error) {
-                        notify({
-                                type: 'error',
-                                message: `Failed to create game: ${error}`,
-                                duration: 5000
-                        });
-                        setShouldFetch(false);
-                }
-                if (data?.gameCode) {
-                        setGameData(data);
-                        window.location.hash = `#lobby-${data.gameCode}`;
-                        setShouldFetch(false);
-                }
-        }, [error, data]);
+	useEffect(() => {
+		if (error) {
+			notify({
+				type: 'error',
+				message: `Failed to create game: ${error}`,
+				duration: 5000
+			});
+			setShouldFetch(false);
+		}
+		if (data?.gameCode) {
+			setGameData(data);
+			window.location.hash = `#lobby-${data.gameCode}`;
+			setShouldFetch(false);
+		}
+	}, [error, data]);
 
 	const handleTimerChange = (hasTimer: boolean, timeMs: number) => {
 		setTimer(timeMs);
 	};
 
-        const handleCreateGame = () => {
-                setShouldFetch(true);
-        };
+	const handleCreateGame = () => {
+		setShouldFetch(true);
+	};
 
 	return (
 		<div>

--- a/frontend-service/src/components/game-setup-modal/StartMultiplayerGameSetup.tsx
+++ b/frontend-service/src/components/game-setup-modal/StartMultiplayerGameSetup.tsx
@@ -1,5 +1,4 @@
-import React, { useState, useEffect } from 'react';
-import { useAuth } from '@clerk/clerk-react';
+import React, { useState, useEffect, useRef } from 'react';
 import { Button } from '../ui/button';
 import { Subheading } from '../typography/Typography';
 import RoundTimerSelectionSlider from '../roundTimerSelectionSlider';
@@ -8,52 +7,53 @@ import { useMultiplayerStore } from '../../store/multiplayerStore';
 import { notify } from '../../context/NotificationContext';
 import { CreateGameResponse } from '../../types/MultiplayerServiceApiResponse.types'
 import { MULTIPLAYER_SERVICE_API_URL } from '../../objects/endpoints'
+import { getPlayerIdentity } from '../../utils/guestIdentityUtils';
 
 
 const StartMultiPlayerGameSetup = () => {
-	const [timer, setTimer] = useState(0);
-	const [shouldFetch, setShouldFetch] = useState(false);
-	const { getToken } = useAuth();
-	const [authToken, setAuthToken] = useState<string | null>(null);
-	const { setGameData } = useMultiplayerStore();
+        const [timer, setTimer] = useState(0);
+        const [shouldFetch, setShouldFetch] = useState(false);
+        const { setGameData } = useMultiplayerStore();
+        const playerIdentityRef = useRef(getPlayerIdentity());
 
-	const { data, isPending, error } = useFetch<CreateGameResponse>(
-		`${MULTIPLAYER_SERVICE_API_URL}/create-game`,
-		{
-			method: 'POST',
-			headers: {
-				'Content-Type': 'application/json',
-				...(authToken && { 'Authorization': `Bearer ${authToken}` }),
-			},
-			body: JSON.stringify({ timer }),
-			enabled: shouldFetch && authToken !== null,
-		}
-	);
+        const { data, isPending, error } = useFetch<CreateGameResponse>(
+                `${MULTIPLAYER_SERVICE_API_URL}/create-game`,
+                {
+                        method: 'POST',
+                        headers: {
+                                'Content-Type': 'application/json',
+                        },
+                        body: JSON.stringify({
+                                timer,
+                                hostId: playerIdentityRef.current.playerId,
+                        }),
+                        enabled: shouldFetch,
+                }
+        );
 
-	useEffect(() => {
-		if (error) {
-			notify({
-				type: 'error',
-				message: `Failed to create game: ${error}`,
-				duration: 5000
-			});
-			setShouldFetch(false);
-		}
-		if (data?.gameCode) {
-			setGameData(data);
-			window.location.hash = `#lobby-${data.gameCode}`;
-		}
-	}, [error, data]);
+        useEffect(() => {
+                if (error) {
+                        notify({
+                                type: 'error',
+                                message: `Failed to create game: ${error}`,
+                                duration: 5000
+                        });
+                        setShouldFetch(false);
+                }
+                if (data?.gameCode) {
+                        setGameData(data);
+                        window.location.hash = `#lobby-${data.gameCode}`;
+                        setShouldFetch(false);
+                }
+        }, [error, data]);
 
 	const handleTimerChange = (hasTimer: boolean, timeMs: number) => {
 		setTimer(timeMs);
 	};
 
-	const handleCreateGame = async () => {
-		const token = await getToken();
-		setAuthToken(token);
-		setShouldFetch(true);
-	};
+        const handleCreateGame = () => {
+                setShouldFetch(true);
+        };
 
 	return (
 		<div>

--- a/frontend-service/src/objects/gameSetupConsts.ts
+++ b/frontend-service/src/objects/gameSetupConsts.ts
@@ -31,7 +31,7 @@ const gameModeCards: GameModeCardType[] = [
 		id: GAME_SETUP_STEPS.START_GAME,
 		title: 'Start Multiplayer Game',
 		description: 'Create a game room and invite friends',
-		enabled: false,
+		enabled: true,
 		fragment: `#${GAME_SETUP_STEPS.START_GAME}`,
 		colorClasses: {
 			bg: 'bg-green-100',
@@ -44,7 +44,7 @@ const gameModeCards: GameModeCardType[] = [
 		id: GAME_SETUP_STEPS.JOIN_GAME,
 		title: 'Join Multiplayer Game',
 		description: 'Join an existing game room',
-		enabled: false,
+		enabled: true,
 		fragment: `#${GAME_SETUP_STEPS.JOIN_GAME}`,
 		colorClasses: {
 			bg: 'bg-violet-100',

--- a/frontend-service/src/objects/gameSetupConsts.ts
+++ b/frontend-service/src/objects/gameSetupConsts.ts
@@ -31,7 +31,7 @@ const gameModeCards: GameModeCardType[] = [
 		id: GAME_SETUP_STEPS.START_GAME,
 		title: 'Start Multiplayer Game',
 		description: 'Create a game room and invite friends',
-		enabled: true,
+		enabled: false,
 		fragment: `#${GAME_SETUP_STEPS.START_GAME}`,
 		colorClasses: {
 			bg: 'bg-green-100',
@@ -44,7 +44,7 @@ const gameModeCards: GameModeCardType[] = [
 		id: GAME_SETUP_STEPS.JOIN_GAME,
 		title: 'Join Multiplayer Game',
 		description: 'Join an existing game room',
-		enabled: true,
+		enabled: false,
 		fragment: `#${GAME_SETUP_STEPS.JOIN_GAME}`,
 		colorClasses: {
 			bg: 'bg-violet-100',

--- a/frontend-service/src/pages/index.tsx
+++ b/frontend-service/src/pages/index.tsx
@@ -6,28 +6,18 @@ import favicon from "../images/favicon.ico"
 import { NotificationProvider } from "../context/NotificationContext"
 import { LoadingProvider } from "../context/LoadingContext"
 import ToastContainer from "../components/ToastContainer"
-import { ClerkProvider } from '@clerk/clerk-react'
-
-const CLERK_PUBLISHABLE_KEY = process.env.GATSBY_CLERK_PUBLISHABLE_KEY as string;
-
-if (!CLERK_PUBLISHABLE_KEY) {
-  throw new Error('Missing Clerk Publishable Key')
-}
-
 const IndexPage: React.FC<PageProps> = () => {
 
   return (
-    <ClerkProvider publishableKey={CLERK_PUBLISHABLE_KEY}>
-      <NotificationProvider>
-        <LoadingProvider>
-          <main className="h-full overflow-hidden">
-            <Game />
-            <MenuBar />
-            <ToastContainer />
-          </main>
-        </LoadingProvider>
-      </NotificationProvider>
-    </ClerkProvider>
+    <NotificationProvider>
+      <LoadingProvider>
+        <main className="h-full overflow-hidden">
+          <Game />
+          <MenuBar />
+          <ToastContainer />
+        </main>
+      </LoadingProvider>
+    </NotificationProvider>
   )
 }
 

--- a/frontend-service/src/tests/components/Game.test.tsx
+++ b/frontend-service/src/tests/components/Game.test.tsx
@@ -14,12 +14,6 @@ vi.mock('../../hooks/useFetch', () => ({
 	useFetch: vi.fn()
 }));
 
-// Mock Clerk hooks
-vi.mock('@clerk/clerk-react', () => ({
-	useAuth: vi.fn(() => ({ isSignedIn: false })),
-	useClerk: vi.fn(() => ({ openSignIn: vi.fn() }))
-}));
-
 // Mock LoadingOverlay to prevent rendering issues in tests
 vi.mock('../../components/LoadingOverlay', () => ({
 	default: ({ message }: { message: string }) => (

--- a/frontend-service/src/tests/components/game-setup-modal/GameSetupModal.test.tsx
+++ b/frontend-service/src/tests/components/game-setup-modal/GameSetupModal.test.tsx
@@ -3,12 +3,6 @@ import { render, screen, fireEvent } from '@testing-library/react'
 import { describe, test, expect, vi, beforeEach } from 'vitest'
 import GameSetupModal from '../../../components/game-setup-modal/GameSetupModal'
 
-// Mock Clerk hooks
-vi.mock('@clerk/clerk-react', () => ({
-	useAuth: vi.fn(() => ({ isSignedIn: false })),
-	useClerk: vi.fn(() => ({ openSignIn: vi.fn() }))
-}));
-
 // Mock game store
 const mockStartGame = vi.fn();
 vi.mock('../../../store/gameStore', () => ({
@@ -28,16 +22,16 @@ vi.mock('../../../components/game-setup-modal/SinglePlayerStartMenu', () => ({
 	)
 }));
 
-vi.mock('../../../components/game-setup-modal/StartMultiPlayerGameSetup', () => ({
-	default: () => <div data-testid="multiplayer-mode">Multiplayer Mode</div>
+vi.mock('../../../components/game-setup-modal/StartMultiplayerGameSetup', () => ({
+        default: () => <div data-testid="multiplayer-mode">Multiplayer Mode</div>
 }));
 
 describe('GameSetupModal', () => {
-	beforeEach(() => {
-		vi.clearAllMocks();
-		// Reset hash
-		window.location.hash = '';
-	});
+        beforeEach(() => {
+                mockStartGame.mockReset();
+                // Reset hash
+                window.location.hash = '';
+        });
 
 	test('renders modal with heading and description', () => {
 		render(<GameSetupModal />);

--- a/frontend-service/src/tests/components/game-setup-modal/GameSetupModal.test.tsx
+++ b/frontend-service/src/tests/components/game-setup-modal/GameSetupModal.test.tsx
@@ -23,15 +23,15 @@ vi.mock('../../../components/game-setup-modal/SinglePlayerStartMenu', () => ({
 }));
 
 vi.mock('../../../components/game-setup-modal/StartMultiplayerGameSetup', () => ({
-        default: () => <div data-testid="multiplayer-mode">Multiplayer Mode</div>
+	default: () => <div data-testid="multiplayer-mode">Multiplayer Mode</div>
 }));
 
 describe('GameSetupModal', () => {
-        beforeEach(() => {
-                mockStartGame.mockReset();
-                // Reset hash
-                window.location.hash = '';
-        });
+	beforeEach(() => {
+		mockStartGame.mockReset();
+		// Reset hash
+		window.location.hash = '';
+	});
 
 	test('renders modal with heading and description', () => {
 		render(<GameSetupModal />);

--- a/frontend-service/src/tests/components/game-setup-modal/Lobby.test.tsx
+++ b/frontend-service/src/tests/components/game-setup-modal/Lobby.test.tsx
@@ -8,94 +8,94 @@ const mockGameData = vi.fn();
 const mockPlayers = vi.fn();
 const mockSetPlayers = vi.fn();
 vi.mock('../../../store/multiplayerStore', () => ({
-        useMultiplayerStore: () => ({
-                gameData: mockGameData(),
-                players: mockPlayers(),
-                setPlayers: mockSetPlayers
-        })
+	useMultiplayerStore: () => ({
+		gameData: mockGameData(),
+		players: mockPlayers(),
+		setPlayers: mockSetPlayers
+	})
 }));
 
 // Mock useGameRoom hook
 const mockConnectionStatus = vi.fn();
 const mockSendMessage = vi.fn();
 vi.mock('../../../hooks/useGameRoom', () => ({
-        useGameRoom: () => ({
-                connectionStatus: mockConnectionStatus(),
-                sendMessage: mockSendMessage
-        })
+	useGameRoom: () => ({
+		connectionStatus: mockConnectionStatus(),
+		sendMessage: mockSendMessage
+	})
 }));
 
 describe('Lobby', () => {
-        beforeEach(() => {
-                vi.clearAllMocks();
-                window.location.hash = '';
-                mockConnectionStatus.mockReturnValue('disconnected');
-                mockPlayers.mockReturnValue([]);
-                localStorage.clear();
-                localStorage.setItem('mapguesser_guest_id', 'guest_player');
-                localStorage.setItem('mapguesser_guest_name', 'Test Player');
-        });
+	beforeEach(() => {
+		vi.clearAllMocks();
+		window.location.hash = '';
+		mockConnectionStatus.mockReturnValue('disconnected');
+		mockPlayers.mockReturnValue([]);
+		localStorage.clear();
+		localStorage.setItem('mapguesser_guest_id', 'guest_player');
+		localStorage.setItem('mapguesser_guest_name', 'Test Player');
+	});
 
-        test('displays game code heading and instructions', () => {
-                window.location.hash = '#lobby-XYZ789';
-                mockGameData.mockReturnValue(null);
+	test('displays game code heading and instructions', () => {
+		window.location.hash = '#lobby-XYZ789';
+		mockGameData.mockReturnValue(null);
 
-                render(<Lobby />);
+		render(<Lobby />);
 
-                expect(screen.getByText('Game Code')).toBeInTheDocument();
-                expect(screen.getByText('Share this code with your friends to join the game!')).toBeInTheDocument();
-        });
+		expect(screen.getByText('Game Code')).toBeInTheDocument();
+		expect(screen.getByText('Share this code with your friends to join the game!')).toBeInTheDocument();
+	});
 
-        test('displays game code from URL hash', () => {
-                window.location.hash = '#lobby-ABC123';
-                mockGameData.mockReturnValue(null);
+	test('displays game code from URL hash', () => {
+		window.location.hash = '#lobby-ABC123';
+		mockGameData.mockReturnValue(null);
 
-                render(<Lobby />);
+		render(<Lobby />);
 
-                expect(screen.getByText('ABC123')).toBeInTheDocument();
-        });
+		expect(screen.getByText('ABC123')).toBeInTheDocument();
+	});
 
-        test('displays waiting for players message', () => {
-                window.location.hash = '#lobby-ABC123';
-                mockGameData.mockReturnValue(null);
+	test('displays waiting for players message', () => {
+		window.location.hash = '#lobby-ABC123';
+		mockGameData.mockReturnValue(null);
 
-                render(<Lobby />);
+		render(<Lobby />);
 
-                expect(screen.getByText('Waiting for players to join...')).toBeInTheDocument();
-        });
+		expect(screen.getByText('Waiting for players to join...')).toBeInTheDocument();
+	});
 
-        test('does not show Start Game button when player is not game owner', () => {
-                window.location.hash = '#lobby-ABC123';
-                mockGameData.mockReturnValue({
-                        gameCode: 'ABC123',
-                        timer: 60000,
-                        gameOwnerId: 'host_999'
-                });
+	test('does not show Start Game button when player is not game owner', () => {
+		window.location.hash = '#lobby-ABC123';
+		mockGameData.mockReturnValue({
+			gameCode: 'ABC123',
+			timer: 60000,
+			gameOwnerId: 'host_999'
+		});
 
-                render(<Lobby />);
+		render(<Lobby />);
 
-                expect(screen.queryByText('Start Game')).not.toBeInTheDocument();
-        });
+		expect(screen.queryByText('Start Game')).not.toBeInTheDocument();
+	});
 
-        test('shows Start Game button when player is game owner', () => {
-                window.location.hash = '#lobby-ABC123';
-                mockGameData.mockReturnValue({
-                        gameCode: 'ABC123',
-                        timer: 60000,
-                        gameOwnerId: 'guest_player'
-                });
+	test('shows Start Game button when player is game owner', () => {
+		window.location.hash = '#lobby-ABC123';
+		mockGameData.mockReturnValue({
+			gameCode: 'ABC123',
+			timer: 60000,
+			gameOwnerId: 'guest_player'
+		});
 
-                render(<Lobby />);
+		render(<Lobby />);
 
-                expect(screen.getByText('Start Game')).toBeInTheDocument();
-        });
+		expect(screen.getByText('Start Game')).toBeInTheDocument();
+	});
 
-        test('does not show Start Game button when gameData is null', () => {
-                window.location.hash = '#lobby-ABC123';
-                mockGameData.mockReturnValue(null);
+	test('does not show Start Game button when gameData is null', () => {
+		window.location.hash = '#lobby-ABC123';
+		mockGameData.mockReturnValue(null);
 
-                render(<Lobby />);
+		render(<Lobby />);
 
-                expect(screen.queryByText('Start Game')).not.toBeInTheDocument();
-        });
+		expect(screen.queryByText('Start Game')).not.toBeInTheDocument();
+	});
 });

--- a/frontend-service/src/tests/components/game-setup-modal/Lobby.test.tsx
+++ b/frontend-service/src/tests/components/game-setup-modal/Lobby.test.tsx
@@ -3,148 +3,99 @@ import { render, screen } from '@testing-library/react';
 import { describe, test, expect, vi, beforeEach } from 'vitest';
 import Lobby from '../../../components/game-setup-modal/Lobby';
 
-// Mock Clerk hooks
-const mockUseUser = vi.fn();
-vi.mock('@clerk/clerk-react', () => ({
-	useUser: () => mockUseUser()
-}));
-
 // Mock multiplayer store
 const mockGameData = vi.fn();
 const mockPlayers = vi.fn();
 const mockSetPlayers = vi.fn();
 vi.mock('../../../store/multiplayerStore', () => ({
-	useMultiplayerStore: () => ({
-		gameData: mockGameData(),
-		players: mockPlayers(),
-		setPlayers: mockSetPlayers
-	})
+        useMultiplayerStore: () => ({
+                gameData: mockGameData(),
+                players: mockPlayers(),
+                setPlayers: mockSetPlayers
+        })
 }));
 
 // Mock useGameRoom hook
 const mockConnectionStatus = vi.fn();
 const mockSendMessage = vi.fn();
 vi.mock('../../../hooks/useGameRoom', () => ({
-	useGameRoom: () => ({
-		connectionStatus: mockConnectionStatus(),
-		sendMessage: mockSendMessage
-	})
-}));
-
-// Mock guest identity utils
-vi.mock('../../../utils/guestIdentityUtils', () => ({
-	getPlayerIdentity: vi.fn(() => ({
-		playerId: 'test-player-id',
-		playerName: 'Test Player',
-		isGuest: true
-	}))
+        useGameRoom: () => ({
+                connectionStatus: mockConnectionStatus(),
+                sendMessage: mockSendMessage
+        })
 }));
 
 describe('Lobby', () => {
-	beforeEach(() => {
-		vi.clearAllMocks();
-		window.location.hash = '';
-		// Set default mock return values
-		mockConnectionStatus.mockReturnValue('disconnected');
-		mockPlayers.mockReturnValue([]);
-	});
+        beforeEach(() => {
+                vi.clearAllMocks();
+                window.location.hash = '';
+                mockConnectionStatus.mockReturnValue('disconnected');
+                mockPlayers.mockReturnValue([]);
+                localStorage.clear();
+                localStorage.setItem('mapguesser_guest_id', 'guest_player');
+                localStorage.setItem('mapguesser_guest_name', 'Test Player');
+        });
 
-	test('displays game code heading and instructions', () => {
-		window.location.hash = '#lobby-XYZ789';
-		mockUseUser.mockReturnValue({ user: null, isSignedIn: false, isLoaded: true });
-		mockGameData.mockReturnValue(null);
+        test('displays game code heading and instructions', () => {
+                window.location.hash = '#lobby-XYZ789';
+                mockGameData.mockReturnValue(null);
 
-		render(<Lobby />);
+                render(<Lobby />);
 
-		expect(screen.getByText('Game Code')).toBeInTheDocument();
-		expect(screen.getByText('Share this code with your friends to join the game!')).toBeInTheDocument();
-	});
+                expect(screen.getByText('Game Code')).toBeInTheDocument();
+                expect(screen.getByText('Share this code with your friends to join the game!')).toBeInTheDocument();
+        });
 
-	test('displays game code from URL hash', () => {
-		window.location.hash = '#lobby-ABC123';
-		mockUseUser.mockReturnValue({ user: null, isSignedIn: false, isLoaded: true });
-		mockGameData.mockReturnValue(null);
+        test('displays game code from URL hash', () => {
+                window.location.hash = '#lobby-ABC123';
+                mockGameData.mockReturnValue(null);
 
-		render(<Lobby />);
+                render(<Lobby />);
 
-		expect(screen.getByText('ABC123')).toBeInTheDocument();
-	});
+                expect(screen.getByText('ABC123')).toBeInTheDocument();
+        });
 
-	test('displays waiting for players message', () => {
-		window.location.hash = '#lobby-ABC123';
-		mockUseUser.mockReturnValue({ user: null, isSignedIn: false, isLoaded: true });
-		mockGameData.mockReturnValue(null);
+        test('displays waiting for players message', () => {
+                window.location.hash = '#lobby-ABC123';
+                mockGameData.mockReturnValue(null);
 
-		render(<Lobby />);
+                render(<Lobby />);
 
-		expect(screen.getByText('Waiting for players to join...')).toBeInTheDocument();
-	});
+                expect(screen.getByText('Waiting for players to join...')).toBeInTheDocument();
+        });
 
-	test('does not show Start Game button when user is not game owner', () => {
-		window.location.hash = '#lobby-ABC123';
-		mockUseUser.mockReturnValue({
-			user: { id: 'user_999' },
-			isSignedIn: true,
-			isLoaded: true
-		});
-		mockGameData.mockReturnValue({
-			gameCode: 'ABC123',
-			timer: 60000,
-			gameOwnerId: 'user_123'
-		});
+        test('does not show Start Game button when player is not game owner', () => {
+                window.location.hash = '#lobby-ABC123';
+                mockGameData.mockReturnValue({
+                        gameCode: 'ABC123',
+                        timer: 60000,
+                        gameOwnerId: 'host_999'
+                });
 
-		render(<Lobby />);
+                render(<Lobby />);
 
-		expect(screen.queryByText('Start Game')).not.toBeInTheDocument();
-	});
+                expect(screen.queryByText('Start Game')).not.toBeInTheDocument();
+        });
 
-	test('shows Start Game button when user is game owner', () => {
-		window.location.hash = '#lobby-ABC123';
-		mockUseUser.mockReturnValue({
-			user: { id: 'user_123' },
-			isSignedIn: true,
-			isLoaded: true
-		});
-		mockGameData.mockReturnValue({
-			gameCode: 'ABC123',
-			timer: 60000,
-			gameOwnerId: 'user_123'
-		});
+        test('shows Start Game button when player is game owner', () => {
+                window.location.hash = '#lobby-ABC123';
+                mockGameData.mockReturnValue({
+                        gameCode: 'ABC123',
+                        timer: 60000,
+                        gameOwnerId: 'guest_player'
+                });
 
-		render(<Lobby />);
+                render(<Lobby />);
 
-		expect(screen.getByText('Start Game')).toBeInTheDocument();
-	});
+                expect(screen.getByText('Start Game')).toBeInTheDocument();
+        });
 
-	test('does not show Start Game button when user is not signed in', () => {
-		window.location.hash = '#lobby-ABC123';
-		mockUseUser.mockReturnValue({
-			user: null,
-			isSignedIn: false,
-			isLoaded: true
-		});
-		mockGameData.mockReturnValue({
-			gameCode: 'ABC123',
-			timer: 60000,
-			gameOwnerId: 'user_123'
-		});
+        test('does not show Start Game button when gameData is null', () => {
+                window.location.hash = '#lobby-ABC123';
+                mockGameData.mockReturnValue(null);
 
-		render(<Lobby />);
+                render(<Lobby />);
 
-		expect(screen.queryByText('Start Game')).not.toBeInTheDocument();
-	});
-
-	test('does not show Start Game button when gameData is null', () => {
-		window.location.hash = '#lobby-ABC123';
-		mockUseUser.mockReturnValue({
-			user: { id: 'user_123' },
-			isSignedIn: true,
-			isLoaded: true
-		});
-		mockGameData.mockReturnValue(null);
-
-		render(<Lobby />);
-
-		expect(screen.queryByText('Start Game')).not.toBeInTheDocument();
-	});
+                expect(screen.queryByText('Start Game')).not.toBeInTheDocument();
+        });
 });

--- a/frontend-service/src/tests/components/game-setup-modal/SelectGameModeMenu.test.tsx
+++ b/frontend-service/src/tests/components/game-setup-modal/SelectGameModeMenu.test.tsx
@@ -1,44 +1,19 @@
 import React from 'react'
 import { render, screen } from '@testing-library/react'
-import { describe, test, expect, vi, beforeEach } from 'vitest'
+import { describe, test, expect } from 'vitest'
 import SelectGameModeMenu from '../../../components/game-setup-modal/SelectGameModeMenu'
 
-// Mock Clerk hooks
-vi.mock('@clerk/clerk-react', () => ({
-	useAuth: vi.fn(() => ({ isSignedIn: false })),
-	useClerk: vi.fn(() => ({ openSignIn: vi.fn() }))
-}));
-
-
 describe('SelectGameModeMenu', () => {
-	beforeEach(() => {
-		vi.clearAllMocks();
-	});
+        test('renders the game mode menu cards', () => {
+                render(<SelectGameModeMenu />);
 
-	test('renders the game mode menu cards', () => {
-		render(<SelectGameModeMenu />);
-		
-		expect(screen.getByText('Single Player Game')).toBeInTheDocument();
-		expect(screen.getByText('Play solo and compete against your own best scores')).toBeInTheDocument();
-		
-		expect(screen.getByText('Start Multiplayer Game')).toBeInTheDocument();
-		expect(screen.getByText('Create a game room and invite friends')).toBeInTheDocument();
-		
-		expect(screen.getByText('Join Multiplayer Game')).toBeInTheDocument();
-		expect(screen.getByText('Join an existing game room')).toBeInTheDocument();
-	});
+                expect(screen.getByText('Single Player Game')).toBeInTheDocument();
+                expect(screen.getByText('Play solo and compete against your own best scores')).toBeInTheDocument();
 
-	// Commenting this out because it's not enabled right now
-	// test('if user is not logged in, dont progress start multiplayer game', () => {
-	// 	const mockOpenSignIn = vi.fn();
-	// 	vi.mocked(useAuth).mockReturnValue({ isSignedIn: false });
-	// 	vi.mocked(useClerk).mockReturnValue({ openSignIn: mockOpenSignIn });
+                expect(screen.getByText('Start Multiplayer Game')).toBeInTheDocument();
+                expect(screen.getByText('Create a game room and invite friends')).toBeInTheDocument();
 
-	// 	render(<SelectGameModeMenu />);
-	// 	
-	// 	const multiplayerCard = screen.getByText('Start Multiplayer Game');
-	// 	fireEvent.click(multiplayerCard);
-	// 	
-	// 	expect(mockOpenSignIn).toHaveBeenCalled();
-	// });
-})
+                expect(screen.getByText('Join Multiplayer Game')).toBeInTheDocument();
+                expect(screen.getByText('Join an existing game room')).toBeInTheDocument();
+        });
+});

--- a/frontend-service/src/tests/components/game-setup-modal/SelectGameModeMenu.test.tsx
+++ b/frontend-service/src/tests/components/game-setup-modal/SelectGameModeMenu.test.tsx
@@ -4,16 +4,16 @@ import { describe, test, expect } from 'vitest'
 import SelectGameModeMenu from '../../../components/game-setup-modal/SelectGameModeMenu'
 
 describe('SelectGameModeMenu', () => {
-        test('renders the game mode menu cards', () => {
-                render(<SelectGameModeMenu />);
+	test('renders the game mode menu cards', () => {
+		render(<SelectGameModeMenu />);
 
-                expect(screen.getByText('Single Player Game')).toBeInTheDocument();
-                expect(screen.getByText('Play solo and compete against your own best scores')).toBeInTheDocument();
+		expect(screen.getByText('Single Player Game')).toBeInTheDocument();
+		expect(screen.getByText('Play solo and compete against your own best scores')).toBeInTheDocument();
 
-                expect(screen.getByText('Start Multiplayer Game')).toBeInTheDocument();
-                expect(screen.getByText('Create a game room and invite friends')).toBeInTheDocument();
+		expect(screen.getByText('Start Multiplayer Game')).toBeInTheDocument();
+		expect(screen.getByText('Create a game room and invite friends')).toBeInTheDocument();
 
-                expect(screen.getByText('Join Multiplayer Game')).toBeInTheDocument();
-                expect(screen.getByText('Join an existing game room')).toBeInTheDocument();
-        });
+		expect(screen.getByText('Join Multiplayer Game')).toBeInTheDocument();
+		expect(screen.getByText('Join an existing game room')).toBeInTheDocument();
+	});
 });

--- a/frontend-service/src/tests/components/game-setup-modal/StartMultiplayerGameSetup.test.tsx
+++ b/frontend-service/src/tests/components/game-setup-modal/StartMultiplayerGameSetup.test.tsx
@@ -33,17 +33,17 @@ vi.mock('../../../components/roundTimerSelectionSlider', () => ({
 }));
 
 describe('StartMultiplayerGameSetup', () => {
-        beforeEach(() => {
-                vi.clearAllMocks();
-                window.location.hash = '';
-                localStorage.clear();
-                localStorage.setItem('mapguesser_guest_id', 'guest_123');
-                localStorage.setItem('mapguesser_guest_name', 'Guest Player');
-                vi.mocked(useFetchHook.useFetch).mockReturnValue({
-                        data: null,
-                        isPending: false,
-                        error: null
-                });
+	beforeEach(() => {
+		vi.clearAllMocks();
+		window.location.hash = '';
+		localStorage.clear();
+		localStorage.setItem('mapguesser_guest_id', 'guest_123');
+		localStorage.setItem('mapguesser_guest_name', 'Guest Player');
+		vi.mocked(useFetchHook.useFetch).mockReturnValue({
+			data: null,
+			isPending: false,
+			error: null
+		});
 	});
 
 	test('renders heading, timer slider, and create button', () => {

--- a/frontend-service/src/tests/components/game-setup-modal/StartMultiplayerGameSetup.test.tsx
+++ b/frontend-service/src/tests/components/game-setup-modal/StartMultiplayerGameSetup.test.tsx
@@ -10,14 +10,6 @@ vi.mock('../../../hooks/useFetch', () => ({
 	useFetch: vi.fn()
 }));
 
-// Mock Clerk hooks
-const mockGetToken = vi.fn();
-vi.mock('@clerk/clerk-react', () => ({
-	useAuth: () => ({
-		getToken: mockGetToken
-	})
-}));
-
 // Mock multiplayer store
 const mockSetGameData = vi.fn();
 vi.mock('../../../store/multiplayerStore', () => ({
@@ -41,15 +33,17 @@ vi.mock('../../../components/roundTimerSelectionSlider', () => ({
 }));
 
 describe('StartMultiplayerGameSetup', () => {
-	beforeEach(() => {
-		vi.clearAllMocks();
-		window.location.hash = '';
-		mockGetToken.mockResolvedValue('mock-token-123');
-		vi.mocked(useFetchHook.useFetch).mockReturnValue({
-			data: null,
-			isPending: false,
-			error: null
-		});
+        beforeEach(() => {
+                vi.clearAllMocks();
+                window.location.hash = '';
+                localStorage.clear();
+                localStorage.setItem('mapguesser_guest_id', 'guest_123');
+                localStorage.setItem('mapguesser_guest_name', 'Guest Player');
+                vi.mocked(useFetchHook.useFetch).mockReturnValue({
+                        data: null,
+                        isPending: false,
+                        error: null
+                });
 	});
 
 	test('renders heading, timer slider, and create button', () => {

--- a/frontend-service/src/utils/guestIdentityUtils.ts
+++ b/frontend-service/src/utils/guestIdentityUtils.ts
@@ -43,14 +43,14 @@ const clearGuestIdentity = (): void => {
 };
 
 const getPlayerIdentity = (): {
-        playerId: string;
-        playerName: string;
-        isGuest: boolean;
+	playerId: string;
+	playerName: string;
+	isGuest: boolean;
 } => {
-        return {
-                playerId: getGuestId(),
-                playerName: getGuestName(),
-                isGuest: true,
+	return {
+		playerId: getGuestId(),
+		playerName: getGuestName(),
+		isGuest: true,
 	};
 };
 

--- a/frontend-service/src/utils/guestIdentityUtils.ts
+++ b/frontend-service/src/utils/guestIdentityUtils.ts
@@ -1,7 +1,6 @@
 /**
  * Utilities for managing guest player identity
  * Guest identities persisted in localStorage.
- * Account identities use Clerk
  */
 
 const GUEST_ID_KEY = 'mapguesser_guest_id';
@@ -43,23 +42,15 @@ const clearGuestIdentity = (): void => {
 	localStorage.removeItem(GUEST_NAME_KEY);
 };
 
-const getPlayerIdentity = (clerkUser?: { id: string; fullName?: string | null }): {
-	playerId: string;
-	playerName: string;
-	isGuest: boolean;
+const getPlayerIdentity = (): {
+        playerId: string;
+        playerName: string;
+        isGuest: boolean;
 } => {
-	if (clerkUser?.id) {
-		return {
-			playerId: clerkUser.id,
-			playerName: clerkUser.fullName || 'Player',
-			isGuest: false,
-		};
-	}
-
-	return {
-		playerId: getGuestId(),
-		playerName: getGuestName(),
-		isGuest: true,
+        return {
+                playerId: getGuestId(),
+                playerName: getGuestName(),
+                isGuest: true,
 	};
 };
 

--- a/frontend-service/src/utils/guestIdentityUtils.ts
+++ b/frontend-service/src/utils/guestIdentityUtils.ts
@@ -1,3 +1,4 @@
+import { Player } from '../types/MultiplayerServiceApiResponse.types'
 /**
  * Utilities for managing guest player identity
  * Guest identities persisted in localStorage.
@@ -42,11 +43,7 @@ const clearGuestIdentity = (): void => {
 	localStorage.removeItem(GUEST_NAME_KEY);
 };
 
-const getPlayerIdentity = (): {
-	playerId: string;
-	playerName: string;
-	isGuest: boolean;
-} => {
+const getPlayerIdentity = (): Player => {
 	return {
 		playerId: getGuestId(),
 		playerName: getGuestName(),


### PR DESCRIPTION
## Summary
- remove Clerk provider and hooks from the frontend multiplayer flow and rely on locally stored guest identities for host detection
- drop Clerk middleware from the multiplayer service, require the client to send a hostId when creating games, and document the new API contract
- clean up dependencies, tests, and documentation to reflect the new unauthenticated multiplayer experience

## Testing
- npm run test:components -- --run
- npm test

------
https://chatgpt.com/codex/tasks/task_e_6903d1612ad883299b1d6e5b1c8b3857